### PR TITLE
Patch IAM policy to make Glue 3.0 working

### DIFF
--- a/cloudformation_template/aws-glue-is-dbt-template.yml
+++ b/cloudformation_template/aws-glue-is-dbt-template.yml
@@ -86,6 +86,7 @@ Resources:
                   - 'glue:BatchDeleteTableVersion'
                   - 'glue:BatchDeleteTable'
                   - 'glue:DeletePartition'
+                  - 'glue:GetUserDefinedFunctions'
                 Effect: Allow
                 Resource:
                   - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog'


### PR DESCRIPTION
*Issue #, Raised in dbt-glue channel in slack community

*Description of changes:*
When working with the default glue version in glue 3.0 I was getting the same error as https://github.com/aws-samples/dbt-glue/issues/77

The issue don't happer when using glue 2.0, but for the sake of completeness we can just add the missing action.

The issue was spotted using GlueSessions running the same command of dbt from a notebook.


